### PR TITLE
Update Werkzeug to 0.15.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pymongo==3.4.0
 requests==2.22.0
 SQLAlchemy==1.3.3
 urllib3==1.25.3
-Werkzeug==0.15.2
+Werkzeug==0.15.6


### PR DESCRIPTION
гитхаб показывает большой страшный жёлтый алерт на странице репозитория. этот апдейт должен его убрать